### PR TITLE
Get BSVE api root at run time

### DIFF
--- a/bsve/server/bsve_wms.py
+++ b/bsve/server/bsve_wms.py
@@ -2,13 +2,15 @@ from base64 import b64encode
 import json
 from urllib import quote
 
-from bsve_wms_styles import BsveWmsStyle
 from girder.api import access
 from girder.api.describe import Description
 from girder.plugins.minerva.rest.dataset import Dataset
 from girder.plugins.minerva.utility.cookie import getExtraHeaders
 
 import requests
+
+from .bsve_wms_styles import BsveWmsStyle
+from .cookie import bsveRoot
 
 
 class BsveWmsDataset(Dataset):
@@ -22,8 +24,8 @@ class BsveWmsDataset(Dataset):
         """ Hits the bsve urls """
 
         # Bsve geoserver (wms get capabilities url)
-        wms = "https://api-qa.bsvecosystem.net/data/v2/" + \
-              "sources/geotiles/meta/list"
+        root = bsveRoot()
+        wms = root + "/data/v2/sources/geotiles/meta/list"
 
         resp = requests.get(wms, headers=getExtraHeaders())
         data = json.loads(resp.text)
@@ -63,7 +65,8 @@ class BsveWmsDataset(Dataset):
         params['layer_info'] = layer_info
         params['adapter'] = 'bsve'
 
-        legend_url = "https://api-dev.bsvecosystem.net/data/v2/sources/geotiles/data/result?"
+        root = bsveRoot()
+        legend_url = root + "/data/v2/sources/geotiles/data/result?"
         legend_qs = quote("$filter=name eq {} and request eq getlegendgraphic and height eq 20 and width eq 20".format(typeName), safe='= ').replace(' ', '+')
 
         r = requests.get(legend_url + legend_qs, headers=headers)

--- a/bsve/server/bsve_wms_styles.py
+++ b/bsve/server/bsve_wms_styles.py
@@ -6,6 +6,8 @@ from girder.plugins.minerva.utility.cookie import getExtraHeaders
 
 import requests
 
+from .cookie import bsveRoot
+
 
 class BsveWmsStyle(object):
     def __init__(self, type_name):
@@ -16,7 +18,8 @@ class BsveWmsStyle(object):
         numeric attribute
         """
 
-        url = "https://api-qa.bsvecosystem.net/data/v2/sources/geoprocessing/request"
+        root = bsveRoot()
+        url = root + "/data/v2/sources/geoprocessing/request"
         headers = getExtraHeaders()
         headers.update({'Content-Type': 'application/xml'})
         xml_data = wps_template(self._type_name, attribute)
@@ -68,7 +71,8 @@ class BsveWmsStyle(object):
 
         layer_params = {}
 
-        base_bsve = "https://api-qa.bsvecosystem.net/data/v2/sources/"
+        root = bsveRoot()
+        base_bsve = root + "/data/v2/sources/"
         headers = getExtraHeaders()
 
         if layer_type == 'vector':

--- a/bsve/server/cookie.py
+++ b/bsve/server/cookie.py
@@ -1,0 +1,7 @@
+import cherrypy
+import urllib
+
+
+def bsveRoot():
+    root = cherrypy.request.cookie.get('bsveRoot').value
+    return urllib.unquote(root)

--- a/bsve/web_client/js/adapters.js
+++ b/bsve/web_client/js/adapters.js
@@ -8,6 +8,7 @@ minerva.rendering.geo.BSVERepresentation = minerva.rendering.geo.defineMapLayer(
      * @fires 'm:map_layer_error' event upon an error defining the layer rendering
      */
     this.init = function (container, dataset) {
+        var bsveapi = 'https://' + BSVE.api.appRoot();
         this.geoJsLayer = container.createLayer('osm', {
             attribution: null,
             keepLower: false
@@ -15,7 +16,7 @@ minerva.rendering.geo.BSVERepresentation = minerva.rendering.geo.defineMapLayer(
         container.addFeatureInfoLayer(this.geoJsLayer);
         var minervaMetadata = dataset.metadata();
         this.geoJsLayer.layerName = minervaMetadata.type_name;
-        var baseUrl = 'https://api-qa.bsvecosystem.net/data/v2/sources/geotiles/data/result'
+        var baseUrl = bsveapi + '/data/v2/sources/geotiles/data/result'
         this.geoJsLayer.baseUrl = '/wms_proxy/' + encodeURIComponent(baseUrl);
         var projection = 'EPSG:3857';
 

--- a/bsve/web_client/js/entryPoint.js
+++ b/bsve/web_client/js/entryPoint.js
@@ -290,7 +290,7 @@ minerva.events.on('g:appload.after', function () {
             }));
 
             // set bsve api root cookie
-            document.cookie = 'bsveRoot=' + 'https://' + BSVE.api.appRoot();
+            document.cookie = 'bsveRoot=' + encodeURIComponent('https://' + BSVE.api.appRoot());
 
             var auth = 'Basic ' + window.btoa(user + ':' + authTicket);
 

--- a/bsve/web_client/js/entryPoint.js
+++ b/bsve/web_client/js/entryPoint.js
@@ -289,6 +289,9 @@ minerva.events.on('g:appload.after', function () {
                 'harbinger-auth-ticket': authTicket
             }));
 
+            // set bsve api root cookie
+            document.cookie = 'bsveRoot=' + 'https://' + BSVE.api.appRoot();
+
             var auth = 'Basic ' + window.btoa(user + ':' + authTicket);
 
             // log in to minerva using bsve credentials


### PR DESCRIPTION
There are authentication issues in the deployed version of GeoViz as a result of hard coded API roots.  When deployed to beta or production, it is still communicating with the qa endpoints where the authentication tokens are not valid.  This makes a client side change removing one instance of hard coded URL's but the following remain:

* https://github.com/OpenGeoscience/minerva-docker/blob/master/bsve/server/bsve_wms.py#L25
* https://github.com/OpenGeoscience/minerva-docker/blob/master/bsve/server/bsve_wms.py#L66
* https://github.com/OpenGeoscience/minerva-docker/blob/master/bsve/server/bsve_wms_styles.py#L19
* https://github.com/OpenGeoscience/minerva-docker/blob/master/bsve/server/bsve_wms_styles.py#L71

There are several ways to fix these:

* Add a parameter containing the base url to all of the BSVE WMS endpoints
* Store the base url in the item metadata on the dataset when created
* Use the `bsveRoot` cookie that I added in this PR (`cherrypy.request.cookie.get('bsveRoot')`)