### PR TITLE
Always sync reference layers on user login

### DIFF
--- a/bsve/web_client/js/entryPoint.js
+++ b/bsve/web_client/js/entryPoint.js
@@ -238,22 +238,7 @@ minerva.events.on('g:appload.after', function () {
             session.once('m:metadata_saved', function () {
                 girder.events.once('g:navigateTo', function (view, obj) {
                     var datasets = obj.datasetsCollection;
-                    var needReference = true;
-                    datasets.each(function (dataset) {
-                        try {
-                            var mm = dataset.attributes.meta.minerva;
-                            if (mm.source && mm.source.layer_source === 'Reference') {
-                                needReference = false;
-                            }
-                        } catch(e) {
-                            console.log('skipping invalid item ' + dataset.id);
-                        }
-                    });
-                    if (needReference) {
-                        init_reference_data(datasets);
-                    } else {
-                        remove_spinner();
-                    }
+                    init_reference_data(datasets);
                 });
                 minerva.router.navigate('session/' + session.id, {trigger: true});
             }).saveMinervaMetadata(resp.meta.minerva);


### PR DESCRIPTION
This takes care of the majority of the issues with importing reference data from the geodata API.  It will compare the list of existing layers with those available and only add layers that are missing.  This means the following:

* It will automatically add new layers as they appear
* It will allow users to delete individual layers to update to the latest metadata

The problem this doesn't solve is the issue of changing metadata.  I.e. if the extent, category, or other piece of metadata of the layer changes, it will not be reflected in the user's list until they manually delete them and refresh the page.  To fix this, we need to make sure the new pieces of metadata added in dataqs gets reliably deployed.